### PR TITLE
Added support for manual APNONCE

### DIFF
--- a/Mac/AutoTSS/devices.ini
+++ b/Mac/AutoTSS/devices.ini
@@ -1,7 +1,15 @@
 [MyiPhone6]
 identifier = iPhone7,2
 ecid = 126537407B6026
-
+apnonces = [
+				"",
+				"603be133ff0bdfa0f83f21e74191cf6770ea43bb",
+				"352dfad1713834f4f94c5ff3c3e5e99477347b95",
+				"42c88f5a7b75bc944c288a7215391dc9c73b6e9f",
+				"0dc448240696866b0cc1b2ac3eca4ce22af11cb3",
+				"9804d99e85bbafd4bb1135a1044773b4df9f1ba3"
+			]
+			
 [MyIphone5S]
 identifier = iPhone6,1
 ecid = 48F29824C78

--- a/Windows/AutoTSS/devices.ini
+++ b/Windows/AutoTSS/devices.ini
@@ -1,7 +1,15 @@
 [MyiPhone6]
 identifier = iPhone7,2
 ecid = 126537407B6026
-
+apnonces = [
+				"",
+				"603be133ff0bdfa0f83f21e74191cf6770ea43bb",
+				"352dfad1713834f4f94c5ff3c3e5e99477347b95",
+				"42c88f5a7b75bc944c288a7215391dc9c73b6e9f",
+				"0dc448240696866b0cc1b2ac3eca4ce22af11cb3",
+				"9804d99e85bbafd4bb1135a1044773b4df9f1ba3"
+			]
+			
 [MyIphone5S]
 identifier = iPhone6,1
 ecid = 48F29824C78


### PR DESCRIPTION
Currently, AutoTSS doesn't support mentioning manual APNONCE which can be good for users based on some recommendations and requirements like from [https://www.reddit.com/r/jailbreak/comments/8p91wa/discussion_latest_advice_from_coolstar_via_his/](this) post.

I added support for multiple APNONCE in devices.ini and adding '' to the list will save shsh with no manual apnonce.